### PR TITLE
Add rendering of measure report html if present

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,7 +300,18 @@ export default function App() {
                   setHTMLs([]);
                 }
               } else if (outputType === 'measureReports') {
-                setResults(Calculator.calculateMeasureReports(measureBundle, [patientBundle], options));
+                const mrResults = Calculator.calculateMeasureReports(measureBundle, [patientBundle], options);
+                const mrs = mrResults.results;
+
+                if (options.calculateHTML) {
+                  const htmls: HTML[] = mrs.map(m => ({
+                    groupId: m.id || '',
+                    html: m.text?.div || ''
+                  }));
+                  setHTMLs(htmls);
+                }
+
+                setResults(mrResults);
               } else if (outputType === 'gapsInCare') {
                 setResults(Calculator.calculateGapsInCare(measureBundle, [patientBundle], options));
               }


### PR DESCRIPTION
Similar to what we do for detailed results, but with the measure report narrative.

To test: run calculation with output type measure reports and the calculate html option selected. Should see similar html output as if you were to run detailed results