### PR TITLE
Update README, add LICENSE and notice.md files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a React app that demonstrates the capabilities of the [fqm-execution](ht
 
 ## Hosted Version
 
-This app is hosted on GitHub Pages, at [https://projecttacoma.github.io/fqm-execution-demo/](https://projecttacoma.github.io/fqm-execution-demo/), for use without standing up a local development environment.
+This app is hosted on GitHub Pages, at [https://projecttacoma.github.io/fqm-execution-demo/](https://projecttacoma.github.io/fqm-execution-demo/), for demonstration use without standing up a local development environment.
 
 ## Options/fields
 
@@ -13,17 +13,17 @@ This app is hosted on GitHub Pages, at [https://projecttacoma.github.io/fqm-exec
 In order to run calculation, the demo app requires a `Bundle` resource that includes the `Measure` resource, all required `Library` resources, and all required `ValueSet` resources. Users can provide measure bundles in three different ways:
 
 * By uploading a measure bundle from their local computer, by clicking on the box below `Upload From File System` or dragging a bundle from their file browser to that box.
-* By selecting a measure bundle from the `Select from Connectathon Repository` dropdown list, which is populated with the measure bundles from the [DBCG/connectathon](https://github.com/dbcg/connectathon) repository.
-* By selecting a measure bundle from the `Select from eCQM Measure Content Repository` dropdown, which is populated from the [cqframework/ecqm-content-r4](https://github.com/cqframework/ecqm-content-r4) repository.
+* By selecting a measure bundle from the `Select From Connectathon Repository` dropdown list, which is populated with the measure bundles from the [DBCG/connectathon](https://github.com/dbcg/connectathon) repository.
+* By selecting a measure bundle from the `Select From eCQM Measure Content Repository` dropdown, which is populated from the [cqframework/ecqm-content-r4](https://github.com/cqframework/ecqm-content-r4) repository.
 
 ### Patient Bundle
 
 In order to run calculation, the demo app requires a `Bundle` resource that includes the `Patient` resource, and all other required clinical resources (`Procedure`s, `Encounter`s, etc.). Users can provide patient bundles in four different ways:
 
 * By uploading a patient bundle from their local computer, by clicking on the box below `Upload From File System` or dragging a bundle from their file browser to that box.
-* By selecting a patient bundle from the `Select from Connectathon Repository` dropdown list, which is populated from the [DBCG/connectathon](https://github.com/dbcg/connectathon) repository if a matching measure is selected in the `Measure Bundle` field.
-* By selecting a patient bundle from the `Select from eCQM Measure Content Repository` dropdown, which is populated from the [cqframework/ecqm-content-r4](https://github.com/cqframework/ecqm-content-r4) repository if a matching measure is selected in the `Measure Bundle` field.
-* By selecting a patient bundle from the `Select from FHIR Patient Generator Repository` dropdown list, which is populated from the [projecttacoma/fhir-patient-generator] repository if a matching measure is selected in the `Measure Bundle` field.
+* By selecting a patient bundle from the `Select From Connectathon Repository` dropdown list, which is populated from the [DBCG/connectathon](https://github.com/dbcg/connectathon) repository if a matching measure is selected in the `Measure Bundle` field.
+* By selecting a patient bundle from the `Select From eCQM Measure Content Repository` dropdown, which is populated from the [cqframework/ecqm-content-r4](https://github.com/cqframework/ecqm-content-r4) repository if a matching measure is selected in the `Measure Bundle` field.
+* By selecting a patient bundle from the `Select From FHIR Patient Generator Repository` dropdown list, which is populated from the [projecttacoma/fhir-patient-generator] repository if a matching measure is selected in the `Measure Bundle` field.
 
 ### Output type
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ In order to run calculation, the demo app requires a `Bundle` resource that incl
 
 * By uploading a patient bundle from their local computer, by clicking on the box below `Upload From File System` or dragging a bundle from their file browser to that box.
 * By selecting a patient bundle from the `Select From Connectathon Repository` dropdown list, which is populated from the [DBCG/connectathon](https://github.com/dbcg/connectathon) repository if a matching measure is selected in the `Measure Bundle` field.
-* By selecting a patient bundle from the `Select From eCQM Measure Content Repository` dropdown, which is populated from the [cqframework/ecqm-content-r4](https://github.com/cqframework/ecqm-content-r4) repository if a matching measure is selected in the `Measure Bundle` field.
 * By selecting a patient bundle from the `Select From FHIR Patient Generator Repository` dropdown list, which is populated from the [projecttacoma/fhir-patient-generator] repository if a matching measure is selected in the `Measure Bundle` field.
+* By selecting a patient bundle from the `Select From eCQM Measure Content Repository` dropdown, which is populated from the [cqframework/ecqm-content-r4](https://github.com/cqframework/ecqm-content-r4) repository if a matching measure is selected in the `Measure Bundle` field.
 
 ### Output type
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
 # fqm-execution-demo
+
+This is a React app that demonstrates the capabilities of the [fqm-execution](https://github.com/projecttacoma/fqm-execution) library in calculating FHIR-based electronic Clinical Quality Measures (eCQMs).
+
+## Hosted Version
+
+This app is hosted on GitHub Pages, at [https://projecttacoma.github.io/fqm-execution-demo/](https://projecttacoma.github.io/fqm-execution-demo/), for use without standing up a local development environment.
+
+## Options/fields
+
+### Measure Bundle
+
+In order to run calculation, the demo app requires a `Bundle` resource that includes the `Measure` resource, all required `Library` resources, and all required `ValueSet` resources. Users can provide measure bundles in three different ways:
+
+* By uploading a measure bundle from their local computer, by clicking on the box below `Upload From File System` or dragging a bundle from their file browser to that box.
+* By selecting a measure bundle from the `Select from Connectathon Repository` dropdown list, which is populated with the measure bundles from the [DBCG/connectathon](https://github.com/dbcg/connectathon) repository.
+* By selecting a measure bundle from the `Select from eCQM Measure Content Repository` dropdown, which is populated from the [cqframework/ecqm-content-r4](https://github.com/cqframework/ecqm-content-r4) repository.
+
+### Patient Bundle
+
+In order to run calculation, the demo app requires a `Bundle` resource that includes the `Patient` resource, and all other required clinical resources (`Procedure`s, `Encounter`s, etc.). Users can provide patient bundles in four different ways:
+
+* By uploading a patient bundle from their local computer, by clicking on the box below `Upload From File System` or dragging a bundle from their file browser to that box.
+* By selecting a patient bundle from the `Select from Connectathon Repository` dropdown list, which is populated from the [DBCG/connectathon](https://github.com/dbcg/connectathon) repository if a matching measure is selected in the `Measure Bundle` field.
+* By selecting a patient bundle from the `Select from eCQM Measure Content Repository` dropdown, which is populated from the [cqframework/ecqm-content-r4](https://github.com/cqframework/ecqm-content-r4) repository if a matching measure is selected in the `Measure Bundle` field.
+* By selecting a patient bundle from the `Select from FHIR Patient Generator Repository` dropdown list, which is populated from the [projecttacoma/fhir-patient-generator] repository if a matching measure is selected in the `Measure Bundle` field.
+
+### Output type
+
+This field selects the type of output from `fqm-execution`'s calculation engine:
+
+* `Raw`: the raw results of executing the patient data against the provided ELM in the measure bundle.
+* `Detailed`: detailed results from the calculation engine, including results for each measure population for the patient.
+* `Measure Reports`: A FHIR `MeasureReport` object containing the calculation results, as well as the evaluated resources.
+* `Gaps In Care`: A report detailing the gaps in care for a given patient (if any).
+
+### Calculation Options
+
+* `Calculate SDEs`: Check to enable calculation of "Supplemental Data Elements" for the provided patient/measure
+* `Calculate HTML`: Check to enable generation of HTML output detailing the logic results for the provided patient/measure, including highlighting.
+
+### Measurement Period
+
+* `Measurement Start`: The first day of the `Measurement Period` used by the measure. Defaults to January 1, 2019.
+* `Measurement End`: The last day of the `Measurement Period` used by the measure. Defaults to December 31, 2019.
+
+## Local Development
+
+To run `fqm-execution-demo` locally, you will need [Node.JS](https://nodejs.org/en/) installed on your system. `fqm-execution-demo` is tested with Node version `12`, but more recent versions may also work.
+
+To install the prerequisites for development: in a terminal window open to the `fqm-execution-demo` base directory, run `npm install`.
+
+To serve the app in development mode, run `npm start`. This will start a webserver that will compile the app and serve it locally on `http://localhost:3000/fqm-execution-demo`. This server will automatically re-compile the app when code in the `src` directory is changed.
+
+To execute the test suite, run `npm test`. This will run all the unit tests, and will "watch" the `src/` directory and re-run the test suite when the source code changes. Press `q` to quit the test watcher.
+
+To execute code style checking, run `npm run prettier`. This will check the style of all code in `src/` against the specified styles for the project. To autofix any automatically fixable issues, run `npm run prettier:fix`.
+
+## License
+
+Copyright 2020 The MITRE Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/notice.md
+++ b/notice.md
@@ -1,0 +1,11 @@
+# NOTICE
+
+This software was produced for the U. S. Government under Contract Number 75FCMC18D0047, and is subject to Federal Acquisition Regulation Clause 52.227-14, Rights in Data-General.
+
+No other use other than that granted to the U. S. Government, or to those acting on behalf of the U. S. Government under that Clause is authorized without the express written permission of The MITRE Corporation.
+
+To the extent necessary MITRE hereby grants express written permission to use, reproduce, distribute, modify, and otherwise leverage this software to the extent permitted by the Apache 2.0 license.
+
+For further information, please contact The MITRE Corporation, Contracts Management Office, 7515 Colshire Drive, McLean, VA 22102-7539, (703) 983-6000.
+
+Copyright 2021 The MITRE Corporation. 


### PR DESCRIPTION
This PR:
* Adds a `LICENSE` file (Apache 2.0)
* Adds a `notice.md` file, based on the CMS/HHS 2021 Data Rights Legend (modified for open source use)
* Updates the `README.md` to detail all the various options available in the app, how to run it locally, and a link to the hosted version
