### PR TITLE
Prioritized reason code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3285,11 +3285,6 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3830,15 +3825,6 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4265,14 +4251,6 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.5.0"
-      },
-      "dependencies": {
-        "fsevents": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-          "optional": true
-        }
       }
     },
     "chownr": {
@@ -6605,9 +6583,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
         }
       }
     },
@@ -6860,12 +6838,6 @@
           "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
         }
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -7347,9 +7319,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
-      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "optional": true
     },
     "function-bind": {
@@ -10461,12 +10433,6 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -11304,9 +11270,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "version": "7.0.36",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -13430,9 +13396,9 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "resolve-url-loader": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.2.tgz",
-      "integrity": "sha512-QEb4A76c8Mi7I3xNKXlRKQSlLBwjUV/ULFMP+G7n3/7tJZ8MG5wsZ3ucxP1Jz8Vevn6fnJsxDx9cIls+utGzPQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.4.tgz",
+      "integrity": "sha512-D3sQ04o0eeQEySLrcz4DsX3saHfsr8/N6tfhblxgZKXxMT2Louargg12oGNfoTRLV09GXhVUe5/qgA5vdgNigg==",
       "requires": {
         "adjust-sourcemap-loader": "3.0.0",
         "camelcase": "5.3.1",
@@ -13440,67 +13406,21 @@
         "convert-source-map": "1.7.0",
         "es6-iterator": "2.0.3",
         "loader-utils": "1.2.3",
-        "postcss": "7.0.21",
+        "postcss": "7.0.36",
         "rework": "1.0.1",
         "rework-visit": "1.0.0",
         "source-map": "0.6.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
         "emojis-list": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
           "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "json5": {
           "version": "1.0.1",
@@ -13518,24 +13438,6 @@
             "big.js": "^5.2.2",
             "emojis-list": "^2.0.0",
             "json5": "^1.0.1"
-          }
-        },
-        "postcss": {
-          "version": "7.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-          "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -15576,9 +15478,9 @@
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "uglify-js": {
-      "version": "3.13.10",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
-      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.0.tgz",
+      "integrity": "sha512-R/tiGB1ZXp2BC+TkRGLwj8xUZgdfT2f4UZEgX6aVjJ5uttPrr4fYmwTWDGqVnBCLbOXRMY6nr/BTbwCtVfps0g==",
       "optional": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -16046,11 +15948,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -16652,11 +16550,7 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -16875,11 +16769,18 @@
           }
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
           "requires": {
             "async-limiter": "~1.0.0"
+          },
+          "dependencies": {
+            "async-limiter": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+              "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+            }
           }
         },
         "yargs": {

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -13,10 +13,8 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
   const guidanceResponseArray = [];
 
   for (let i = 0; i < guidanceResponses.length; i++) {
-    if (
-      fhirpath.evaluate(guidanceResponses[i], 'reasonCode.coding.code') === Enums.CareGapReasonCode.MISSING ||
-      fhirpath.evaluate(guidanceResponses[i], 'reasonCode.coding.code') === Enums.CareGapReasonCode.PRESENT
-    ) {
+    const reasonCode = fhirpath.evaluate(guidanceResponses[i], 'reasonCode.coding.code')[0];
+    if (reasonCode === Enums.CareGapReasonCode.MISSING || reasonCode === Enums.CareGapReasonCode.PRESENT) {
       guidanceResponseArray.push(guidanceResponses[i]);
     } else {
       guidanceResponseArray.unshift(guidanceResponses[i]);

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -10,9 +10,9 @@ interface Props {
 
 const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
   const guidanceResponses = fhirpath.evaluate(detectedIssue, 'contained.GuidanceResponse');
-  const guidanceResponseArray: any[] = [];
+  const guidanceResponseArray: R4.IGuidanceResponse[] = [];
 
-  guidanceResponses.forEach((element: any) => {
+  guidanceResponses.forEach((element: R4.IGuidanceResponse) => {
     const reasonCode = fhirpath.evaluate(element, 'reasonCode.coding.code')[0];
     if (reasonCode === Enums.CareGapReasonCode.MISSING || reasonCode === Enums.CareGapReasonCode.PRESENT) {
       guidanceResponseArray.push(element);

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -10,16 +10,16 @@ interface Props {
 
 const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
   const guidanceResponses = fhirpath.evaluate(detectedIssue, 'contained.GuidanceResponse');
-  const guidanceResponseArray = [];
+  const guidanceResponseArray: any[] = [];
 
-  for (let i = 0; i < guidanceResponses.length; i++) {
-    const reasonCode = fhirpath.evaluate(guidanceResponses[i], 'reasonCode.coding.code')[0];
+  guidanceResponses.forEach((element: any) => {
+    const reasonCode = fhirpath.evaluate(element, 'reasonCode.coding.code')[0];
     if (reasonCode === Enums.CareGapReasonCode.MISSING || reasonCode === Enums.CareGapReasonCode.PRESENT) {
-      guidanceResponseArray.push(guidanceResponses[i]);
+      guidanceResponseArray.push(element);
     } else {
-      guidanceResponseArray.unshift(guidanceResponses[i]);
+      guidanceResponseArray.unshift(element);
     }
-  }
+  });
 
   return (
     <div>

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -37,7 +37,7 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
             </AccordionSummary>
             <AccordionDetails>
               <Grid container item xs direction="row">
-                <Grid container xs={6} direction="column">
+                <Grid container item xs={6} direction="column">
                   <Grid item xs>
                     <h4>dataRequirement:</h4>
                   </Grid>
@@ -59,7 +59,7 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                   <Grid item xs>
                     {fhirpath.evaluate(response, 'dataRequirement.codeFilter.code.code').map((code: string) => {
                       return (
-                        <Grid item xs>
+                        <Grid item xs key={code}>
                           code: {code}
                         </Grid>
                       );

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Accordion, AccordionSummary, AccordionDetails, Grid, Typography } from '@material-ui/core';
 import { R4 } from '@ahryman40k/ts-fhir-types';
+import { Enums } from 'fqm-execution';
 import fhirpath from 'fhirpath';
 
 interface Props {
@@ -8,7 +9,19 @@ interface Props {
 }
 
 const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
-  const guidanceResponseArray = fhirpath.evaluate(detectedIssue, 'contained.GuidanceResponse');
+  const guidanceResponses = fhirpath.evaluate(detectedIssue, 'contained.GuidanceResponse');
+  const guidanceResponseArray = [];
+
+  for (let i = 0; i < guidanceResponses.length; i++) {
+    if (
+      fhirpath.evaluate(guidanceResponses[i], 'reasonCode.coding.code') === Enums.CareGapReasonCode.MISSING ||
+      fhirpath.evaluate(guidanceResponses[i], 'reasonCode.coding.code') === Enums.CareGapReasonCode.PRESENT
+    ) {
+      guidanceResponseArray.push(guidanceResponses[i]);
+    } else {
+      guidanceResponseArray.unshift(guidanceResponses[i]);
+    }
+  }
 
   return (
     <div>


### PR DESCRIPTION
**Summary**
In fqm-execution-demo, guidance responses with reason details that are not "Missing" or "Present" are prioritized, meaning that they are the first guidance responses listed.

**New behavior**
When running gaps in care, the guidance responses with reason code "Missing" or "Present" are now at the bottom. This was especially important for Bryn's new bundle because guidance responses with other reason codes were at the bottom.

**Code changes**
All code changes were made in DetectedIssueResources.tsx. All of the code to render the accordion remains the same, I just manipulated the guidanceResponseArray so that any guidance responses with reason codes other than "Missing" or "Present" were at the beginning of the array.

**Testing guidance**
I tested this with EX130 although the changes will not be obvious here since the array is already in the desired order. I would still check this to ensure that it is still working. I also tested it with ColorectalCancerScreeningCQM-bundle.json because the array in that bundle is not in the desired order. In addition, using this new bundle meant that I had to upgrade to fqm-execution version 0.5.0 for it to work.
