### PR TITLE
Added Support for Data Requirements OutputType

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,11 @@ export default function App() {
         setResults(results);
       }
     } else if (outputType === 'dataRequirement') {
+<<<<<<< HEAD
       if (measureFile.content) {
+=======
+      if (measureFile.content && !patientFile.content) {
+>>>>>>> 6baf112 (Added DataRequirements functionality)
         const { results } = Calculator.calculateDataRequirements(measureFile.content);
         setResults(results);
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,6 +149,11 @@ export default function App() {
 
         setResults(results);
       }
+    } else if (outputType === 'dataRequirement') {
+      if (measureFile.content && !patientFile.content) {
+        const { results } = Calculator.calculateDataRequirements(measureFile.content);
+        setResults(results);
+      }
     }
   };
 
@@ -208,7 +213,7 @@ export default function App() {
             color="primary"
             onClick={onCalculateButtonClick}
             className={classes.buttons}
-            disabled={measureFile.content === null || patientFile.content === null}
+            disabled={measureFile.content === null || (patientFile.content === null && outputType !== 'dataRequirement')}
           >
             Calculate
           </Button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,11 +150,7 @@ export default function App() {
         setResults(results);
       }
     } else if (outputType === 'dataRequirement') {
-<<<<<<< HEAD
       if (measureFile.content) {
-=======
-      if (measureFile.content && !patientFile.content) {
->>>>>>> 6baf112 (Added DataRequirements functionality)
         const { results } = Calculator.calculateDataRequirements(measureFile.content);
         setResults(results);
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -213,7 +213,9 @@ export default function App() {
             color="primary"
             onClick={onCalculateButtonClick}
             className={classes.buttons}
-            disabled={measureFile.content === null || (patientFile.content === null && outputType !== 'dataRequirement')}
+            disabled={
+              measureFile.content === null || (patientFile.content === null && outputType !== 'dataRequirement')
+            }
           >
             Calculate
           </Button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,7 @@ export default function App() {
         setResults(results);
       }
     } else if (outputType === 'dataRequirement') {
-      if (measureFile.content && !patientFile.content) {
+      if (measureFile.content) {
         const { results } = Calculator.calculateDataRequirements(measureFile.content);
         setResults(results);
       }

--- a/src/components/CalculationOptions/CalculationOptions.tsx
+++ b/src/components/CalculationOptions/CalculationOptions.tsx
@@ -18,25 +18,35 @@ function CalculationOptionsButtons() {
 
   const shouldCheckSDE = () => {
     return (
-      outputType !== 'rawResults' && calculationOptions.reportType === 'individual' && calculationOptions.calculateSDEs
+      outputType !== 'rawResults' &&
+      outputType !== 'dataRequirement' &&
+      calculationOptions.reportType === 'individual' &&
+      calculationOptions.calculateSDEs
     );
   };
 
   const shouldDisableSDE = () => {
     return (
-      outputType === 'rawResults' || (outputType === 'measureReports' && calculationOptions.reportType === 'summary')
+      outputType === 'rawResults' ||
+      outputType === 'dataRequirement' ||
+      (outputType === 'measureReports' && calculationOptions.reportType === 'summary')
     );
   };
 
   const shouldCheckHTML = () => {
     return (
-      outputType !== 'rawResults' && calculationOptions.reportType !== 'summary' && calculationOptions.calculateHTML
+      outputType !== 'rawResults' &&
+      outputType !== 'dataRequirement' &&
+      calculationOptions.reportType !== 'summary' &&
+      calculationOptions.calculateHTML
     );
   };
 
   const shouldDisableHTML = () => {
     return (
-      outputType === 'rawResults' || (outputType === 'measureReports' && calculationOptions.reportType === 'summary')
+      outputType === 'rawResults' ||
+      outputType === 'dataRequirement' ||
+      (outputType === 'measureReports' && calculationOptions.reportType === 'summary')
     );
   };
 

--- a/src/components/CalculationOptions/MeasurementPeriod.tsx
+++ b/src/components/CalculationOptions/MeasurementPeriod.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import DateFnsUtils from '@date-io/date-fns';
 import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
-import { useRecoilState } from 'recoil';
-import { measurementPeriodState } from '../../state';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { measurementPeriodState, outputTypeState } from '../../state';
 
 function MeasurementPeriodDatePicker() {
   const [measurementPeriod, setMeasurementPeriod] = useRecoilState(measurementPeriodState);
@@ -21,12 +21,24 @@ function MeasurementPeriodDatePicker() {
     });
   };
 
+  const outputType = useRecoilValue(outputTypeState);
+
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils}>
       <h3>Measurement Start: </h3>
-      <DatePicker value={measurementPeriod.measurementPeriodStart} format="MM/dd/yyyy" onChange={setStart} />
+      <DatePicker 
+      value={measurementPeriod.measurementPeriodStart} 
+      format="MM/dd/yyyy" 
+      onChange={setStart} 
+      disabled={outputType === 'dataRequirement'}
+      />
       <h3>Measurement End: </h3>
-      <DatePicker value={measurementPeriod.measurementPeriodEnd} format="MM/dd/yyyy" onChange={setEnd} />
+      <DatePicker 
+      value={measurementPeriod.measurementPeriodEnd} 
+      format="MM/dd/yyyy" 
+      onChange={setEnd} 
+      disabled={outputType === 'dataRequirement'}
+      />
     </MuiPickersUtilsProvider>
   );
 }

--- a/src/components/CalculationOptions/MeasurementPeriod.tsx
+++ b/src/components/CalculationOptions/MeasurementPeriod.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import DateFnsUtils from '@date-io/date-fns';
 import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { measurementPeriodState, outputTypeState } from '../../state';
+import { useRecoilState } from 'recoil';
+import { measurementPeriodState } from '../../state';
 
 function MeasurementPeriodDatePicker() {
   const [measurementPeriod, setMeasurementPeriod] = useRecoilState(measurementPeriodState);
@@ -21,24 +21,12 @@ function MeasurementPeriodDatePicker() {
     });
   };
 
-  const outputType = useRecoilValue(outputTypeState);
-
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils}>
       <h3>Measurement Start: </h3>
-      <DatePicker
-        value={measurementPeriod.measurementPeriodStart}
-        format="MM/dd/yyyy"
-        onChange={setStart}
-        disabled={outputType === 'dataRequirement'}
-      />
+      <DatePicker value={measurementPeriod.measurementPeriodStart} format="MM/dd/yyyy" onChange={setStart} />
       <h3>Measurement End: </h3>
-      <DatePicker
-        value={measurementPeriod.measurementPeriodEnd}
-        format="MM/dd/yyyy"
-        onChange={setEnd}
-        disabled={outputType === 'dataRequirement'}
-      />
+      <DatePicker value={measurementPeriod.measurementPeriodEnd} format="MM/dd/yyyy" onChange={setEnd} />
     </MuiPickersUtilsProvider>
   );
 }

--- a/src/components/CalculationOptions/MeasurementPeriod.tsx
+++ b/src/components/CalculationOptions/MeasurementPeriod.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import DateFnsUtils from '@date-io/date-fns';
 import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { measurementPeriodState, outputTypeState } from '../../state';
+import { useRecoilState } from 'recoil';
+import { measurementPeriodState } from '../../state';
 
 function MeasurementPeriodDatePicker() {
   const [measurementPeriod, setMeasurementPeriod] = useRecoilState(measurementPeriodState);

--- a/src/components/CalculationOptions/MeasurementPeriod.tsx
+++ b/src/components/CalculationOptions/MeasurementPeriod.tsx
@@ -21,24 +21,12 @@ function MeasurementPeriodDatePicker() {
     });
   };
 
-  const outputType = useRecoilValue(outputTypeState);
-
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils}>
       <h3>Measurement Start: </h3>
-      <DatePicker
-        value={measurementPeriod.measurementPeriodStart}
-        format="MM/dd/yyyy"
-        onChange={setStart}
-        disabled={outputType === 'dataRequirement'}
-      />
+      <DatePicker value={measurementPeriod.measurementPeriodStart} format="MM/dd/yyyy" onChange={setStart} />
       <h3>Measurement End: </h3>
-      <DatePicker
-        value={measurementPeriod.measurementPeriodEnd}
-        format="MM/dd/yyyy"
-        onChange={setEnd}
-        disabled={outputType === 'dataRequirement'}
-      />
+      <DatePicker value={measurementPeriod.measurementPeriodEnd} format="MM/dd/yyyy" onChange={setEnd} />
     </MuiPickersUtilsProvider>
   );
 }

--- a/src/components/CalculationOptions/MeasurementPeriod.tsx
+++ b/src/components/CalculationOptions/MeasurementPeriod.tsx
@@ -26,18 +26,18 @@ function MeasurementPeriodDatePicker() {
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils}>
       <h3>Measurement Start: </h3>
-      <DatePicker 
-      value={measurementPeriod.measurementPeriodStart} 
-      format="MM/dd/yyyy" 
-      onChange={setStart} 
-      disabled={outputType === 'dataRequirement'}
+      <DatePicker
+        value={measurementPeriod.measurementPeriodStart}
+        format="MM/dd/yyyy"
+        onChange={setStart}
+        disabled={outputType === 'dataRequirement'}
       />
       <h3>Measurement End: </h3>
-      <DatePicker 
-      value={measurementPeriod.measurementPeriodEnd} 
-      format="MM/dd/yyyy" 
-      onChange={setEnd} 
-      disabled={outputType === 'dataRequirement'}
+      <DatePicker
+        value={measurementPeriod.measurementPeriodEnd}
+        format="MM/dd/yyyy"
+        onChange={setEnd}
+        disabled={outputType === 'dataRequirement'}
       />
     </MuiPickersUtilsProvider>
   );

--- a/src/components/CalculationOptions/OutputType.tsx
+++ b/src/components/CalculationOptions/OutputType.tsx
@@ -24,6 +24,7 @@ function OutputTypeButtons() {
         <FormControlLabel control={<Radio color="primary" />} value="rawResults" label="Raw" />
         <FormControlLabel control={<Radio color="primary" />} value="detailedResults" label="Detailed" />
         <FormControlLabel control={<Radio color="primary" />} value="measureReports" label="Measure Reports" />
+        <FormControlLabel control={<Radio color="primary" />} value="dataRequirement" label="Data Requirements" />
       </RadioGroup>
     </FormControl>
   );

--- a/src/components/Dropdowns/FileImportDropdowns.tsx
+++ b/src/components/Dropdowns/FileImportDropdowns.tsx
@@ -10,7 +10,8 @@ import {
   measureFileState,
   patientDropdownOptionsState,
   patientFileState,
-  resultsState
+  resultsState,
+  outputTypeState
 } from '../../state';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -75,6 +76,7 @@ export function PatientDropdown() {
   const measureFile = useRecoilValue(measureFileState);
   const patientOptions = useRecoilValue(patientDropdownOptionsState);
   const setResults = useSetRecoilState(resultsState);
+  const outputType = useRecoilValue(outputTypeState);
 
   const onPatientDropdownChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setResults(null);
@@ -99,7 +101,7 @@ export function PatientDropdown() {
         <Select
           value={patientFile.name || ''}
           onChange={onPatientDropdownChange}
-          disabled={patientFile.content !== null && patientFile.fromFileUpload === true}
+          disabled={(patientFile.content !== null && patientFile.fromFileUpload === true) || (outputType === 'dataRequirement')}
         >
           {patientOptions.map(option => (
             <MenuItem key={option} value={option}>

--- a/src/components/Dropdowns/FileImportDropdowns.tsx
+++ b/src/components/Dropdowns/FileImportDropdowns.tsx
@@ -101,7 +101,9 @@ export function PatientDropdown() {
         <Select
           value={patientFile.name || ''}
           onChange={onPatientDropdownChange}
-          disabled={(patientFile.content !== null && patientFile.fromFileUpload === true) || (outputType === 'dataRequirement')}
+          disabled={
+            (patientFile.content !== null && patientFile.fromFileUpload === true) || outputType === 'dataRequirement'
+          }
         >
           {patientOptions.map(option => (
             <MenuItem key={option} value={option}>

--- a/src/components/FileUpload/FileUpload.tsx
+++ b/src/components/FileUpload/FileUpload.tsx
@@ -2,9 +2,9 @@ import { R4 } from '@ahryman40k/ts-fhir-types';
 import { Grid } from '@material-ui/core';
 import React, { useCallback } from 'react';
 import { DropzoneRootProps, useDropzone } from 'react-dropzone';
-import { useSetRecoilState } from 'recoil';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
-import { measureFileState, patientFileState, resultsState } from '../../state';
+import { measureFileState, patientFileState, resultsState, outputTypeState } from '../../state';
 
 const getColor = (props: DropzoneRootProps) => {
   if (props.isDragAccept) {
@@ -74,6 +74,7 @@ export const MeasureFileUpload = () => {
 export const PatientFileUpload = () => {
   const setPatientFileState = useSetRecoilState(patientFileState);
   const setResults = useSetRecoilState(resultsState);
+  const outputType = useRecoilValue(outputTypeState);
 
   const onPatientUpload = useCallback(
     files => {
@@ -94,7 +95,8 @@ export const PatientFileUpload = () => {
 
   const { getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject } = useDropzone({
     onDrop: onPatientUpload,
-    accept: '.json'
+    accept: '.json',
+    disabled: outputType === 'dataRequirement'
   });
 
   return (

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -77,8 +77,8 @@ const Results: React.FC<Props> = ({ measureFile, patientFile, htmls }) => {
             </IconButton>
           )}
           {results && <ReactJson src={results} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />}
-          {patientFile && <h2>Patient Bundle:</h2>}
-          {patientFile && (
+          {patientFile && outputType !== 'dataRequirement' && <h2>Patient Bundle:</h2>}
+          {patientFile && outputType !== 'dataRequirement' && (
             <ReactJson src={patientFile} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />
           )}
         </Grid>


### PR DESCRIPTION
### Summary
A radio button was added to the demo app that allows the user to obtain data requirements output, presented in JSON format. 

### New behavior
When the user selects the radio button for data requirements, all the patient upload features are grayed out because this output type does not rely on patient bundles - it only depends on measure bundles. The calculation options, report type, and measurement period are also grayed out for data requirements because they are not relevant to this output type. So, when the user selects the data requirements output type, uploads/selects a measure bundle, and clicks the "Calculate" button, the user is brought to a separate screen with the desired JSON output for data requirements. 

### Code changes
The `src/components/CalculationOptions/OutputType.tsx` file now contains a radio button for the data requirements output. Various components have logic changes to reflect whether the features should be disabled (grayed out) or not, depending on which output type is selected. If the data requirements output type is selected, everything should be grayed out except for the measure bundle upload features. These changes can be found in `src/components/CalculationOptions/CalculationOptions.tsx`, `src/components/CalculationOptions/MeasurementPeriod.tsx`, `src/components/Dropdowns/FileImportDropdowns.tsx`, and `src/components/FileUpload/FileUpload.tsx`. The file `src/App.tsx` contains new code to generate the results for the data requirements output type.

### Testing guidance
Run the fqm-execution demo app and check that previous functionality remains the same for the other output types. Then, try selecting Data Requirements as the output type and choose a measure bundle, either from the respository or as an upload from your local machine. Check that the appropriate JSON output appears on a separate screen. Also check that all the other features (patient upload, calculation options, report type, measurement period) are grayed out and cannot be accessed. 

Note: if you upload a patient bundle before selecting the data requirements output type, the uploaded patient bundle will remain on the screen. This is fine for now and is expected. Check that if you upload a patient bundle and then click on the data requirements output type, you cannot try to upload a new patient bundle. You should be able to delete the previously uploaded patient bundle, but you should not be able to select a new one.
