### PR TITLE
Added dynamic output tabs to results page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3825,6 +3825,15 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6838,6 +6847,12 @@
           "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -10433,6 +10448,12 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -12915,6 +12936,15 @@
         "webpack-dev-server": "3.11.0",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "5.1.4"
+      }
+    },
+    "react-tabs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.2.2.tgz",
+      "integrity": "sha512-/o52eGKxFHRa+ssuTEgSM8qORnV4+k7ibW+aNQzKe+5gifeVz8nLxCrsI9xdRhfb0wCLdgIambIpb1qCxaMN+A==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "prop-types": "^15.5.0"
       }
     },
     "react-textarea-autosize": {
@@ -15948,7 +15978,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -16550,7 +16584,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, Grid, IconButton, AppBar, Tab, Tabs, Toolbar } from '@material-ui/core';
+import { makeStyles, Grid, IconButton, AppBar, Tab, Tabs } from '@material-ui/core';
 import TabPanel from '@material-ui/lab/TabPanel';
 import TabContext from '@material-ui/lab/TabContext';
 import ReactJson from 'react-json-view';

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -1,4 +1,6 @@
-import { makeStyles, Grid, IconButton } from '@material-ui/core';
+import { makeStyles, Grid, IconButton, AppBar, Tab, Tabs } from '@material-ui/core';
+import TabPanel from '@material-ui/lab/TabPanel';
+import TabContext from '@material-ui/lab/TabContext';
 import ReactJson from 'react-json-view';
 import parse from 'html-react-parser';
 import fileDownload from 'js-file-download';
@@ -11,6 +13,7 @@ import { useRecoilValue } from 'recoil';
 import { calculationOptionsState, outputTypeState, resultsState } from '../../state';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import fhirpath from 'fhirpath';
+
 
 const useStyles = makeStyles(() => ({
   highlightedMarkup: {
@@ -33,43 +36,29 @@ const Results: React.FC<Props> = ({ measureFile, patientFile, htmls }) => {
   const results = useRecoilValue(resultsState);
   const detectedIssues = fhirpath.evaluate(results, 'Bundle.entry.resource.DetectedIssue');
 
+  const style = {
+     minWidth: '25%'
+  }
+
+  const [value, setValue] = React.useState('0');
+
+  const handleChange = (event: React.ChangeEvent<{}>, newValue: string) => {
+    setValue(newValue);
+  }
+
   return (
     <Grid container xs={12} direction="column" spacing={2}>
       <h2>Results:</h2>
-      <Grid container item xs={12} direction="row" justify="center" alignItems="center">
-        {outputType === 'measureReports' &&
-          calculationOptions.reportType === 'individual' &&
-          fhirpath.evaluate(results, 'MeasureReport.group').map((group: R4.IMeasureReport_Group) => {
-            const id = results ? fhirpath.evaluate(results, 'MeasureReport.subject.reference')[0].split('/') : '';
-            return (
-              <Grid container item xs={12} direction="column" justify="center" alignItems="center" key={group.id}>
-                <h2>{group.id} Population Results</h2>
-                <PopulationResults key={group.id} results={group} id={id} />
-              </Grid>
-            );
-          })}
-        {results &&
-          detectedIssues.map((issue: R4.IDetectedIssue, index: number) => {
-            const detectedIssueId = fhirpath.evaluate(issue, 'id');
-            return (
-              <Grid
-                container
-                item
-                xs={12}
-                direction="column"
-                justify="center"
-                alignItems="center"
-                key={detectedIssueId}
-              >
-                <h3>Detected Issue {index + 1}</h3>
-                <h4>{fhirpath.evaluate(issue, 'contained.GuidanceResponse').length} Guidance Response(s)</h4>
-                <DetectedIssueResources detectedIssue={issue} />
-              </Grid>
-            );
-          })}
-      </Grid>
-      <Grid container item xs={12} direction="row">
-        <Grid item xs>
+      <TabContext value={value}>
+        <AppBar position="static">
+          <Tabs aria-label="results tabs" onChange = {handleChange} value = {value} indicatorColor="primary" textColor="primary" centered>
+            <Tab style={style} label="Raw JSON" value='0'/>
+            <Tab style={style} label="Highlighted HTML" value='1' />
+            <Tab style={style} label="Tabular" value='2' />
+            <Tab style={style} label="Accordion" value='3' />
+          </Tabs>
+        </AppBar>
+        <TabPanel value = '0'>
           <Grid container item xs direction="row">
             {results && <h2>JSON:</h2>}
             {results && (
@@ -92,21 +81,60 @@ const Results: React.FC<Props> = ({ measureFile, patientFile, htmls }) => {
           {patientFile && (
             <ReactJson src={patientFile} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />
           )}
-        </Grid>
-        <Grid item xs>
-          {results &&
-            htmls &&
-            htmls.map(html => {
-              return (
-                <div key={html.groupId} className={classes.highlightedMarkup}>
-                  <h2>HTML:</h2>
-                  {parse(html.html)}
-                </div>
-              );
+        </TabPanel>
+        <TabPanel value = '1'> 
+          <Grid item xs>
+              {results &&
+                htmls &&
+                htmls.map(html => {
+                  return (
+                    <div key={html.groupId} className={classes.highlightedMarkup}>
+                      <h2>HTML:</h2>
+                      {parse(html.html)}
+                    </div>
+                  );
+                })}
+            </Grid>
+        </TabPanel>
+        <TabPanel value = '2'>
+          <Grid container item xs={12} direction="row" justify="center" alignItems="center">
+            {outputType === 'measureReports' &&
+              calculationOptions.reportType === 'individual' &&
+              fhirpath.evaluate(results, 'MeasureReport.group').map((group: R4.IMeasureReport_Group) => {
+                const id = results ? fhirpath.evaluate(results, 'MeasureReport.subject.reference')[0].split('/') : '';
+                return (
+                  <Grid container item xs={12} direction="column" justify="center" alignItems="center" key={group.id}>
+                    <h2>{group.id} Population Results</h2>
+                    <PopulationResults key={group.id} results={group} id={id} />
+                  </Grid>
+                );
             })}
-        </Grid>
-      </Grid>
+          </Grid>
+        </TabPanel>
+        <TabPanel value = '3'>
+          {results &&
+              detectedIssues.map((issue: R4.IDetectedIssue, index: number) => {
+                const detectedIssueId = fhirpath.evaluate(issue, 'id');
+                return (
+                  <Grid
+                    container
+                    item
+                    xs={12}
+                    direction="column"
+                    justify="center"
+                    alignItems="center"
+                    key={detectedIssueId}
+                  >
+                    <h3>Detected Issue {index + 1}</h3>
+                    <h4>{fhirpath.evaluate(issue, 'contained.GuidanceResponse').length} Guidance Response(s)</h4>
+                    <DetectedIssueResources detectedIssue={issue} />
+                  </Grid>
+                );
+              })}
+        </TabPanel>
+      </TabContext>
     </Grid>
+    
   );
 };
 

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -1,6 +1,5 @@
 import { makeStyles, Grid, IconButton, AppBar, Tab, Tabs } from '@material-ui/core';
-import TabPanel from '@material-ui/lab/TabPanel';
-import TabContext from '@material-ui/lab/TabContext';
+import { TabContext, TabPanel } from '@material-ui/lab';
 import ReactJson from 'react-json-view';
 import parse from 'html-react-parser';
 import fileDownload from 'js-file-download';

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -14,7 +14,6 @@ import { calculationOptionsState, outputTypeState, resultsState } from '../../st
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import fhirpath from 'fhirpath';
 
-
 const useStyles = makeStyles(() => ({
   highlightedMarkup: {
     '& pre': {
@@ -37,162 +36,149 @@ const Results: React.FC<Props> = ({ measureFile, patientFile, htmls }) => {
   const detectedIssues = fhirpath.evaluate(results, 'Bundle.entry.resource.DetectedIssue');
 
   const style = {
-     minWidth: '25%'
-  }
+    minWidth: '25%'
+  };
 
   const [value, setValue] = React.useState('0');
 
   const handleChange = (event: React.ChangeEvent<{}>, newValue: string) => {
     setValue(newValue);
-  }
+  };
 
   const displayJSONResults = () => {
     return (
-    <>
-    <Grid container item xs direction="row">
-      {results && <h2>JSON:</h2>}
-      {results && (
-        <IconButton
-          onClick={() => {
-            fileDownload(
-              JSON.stringify(results, null, 2),
-              measureFile.name?.includes('.json')
-                ? `results-${measureFile.name}`
-                : `results-${measureFile.name}.json`
-            );
-          }}
-        >
-          <GetApp fontSize="small" />
-        </IconButton>
-      )}
-    </Grid>
-    {results && <ReactJson src={results} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />}
-    {patientFile && <h2>Patient Bundle:</h2>}
-    {patientFile && (
-      <ReactJson src={patientFile} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />
-    )}
-    </>
-    )
-  }
+      <>
+        <Grid container item xs direction="row">
+          {results && <h2>JSON:</h2>}
+          {results && (
+            <IconButton
+              onClick={() => {
+                fileDownload(
+                  JSON.stringify(results, null, 2),
+                  measureFile.name?.includes('.json')
+                    ? `results-${measureFile.name}`
+                    : `results-${measureFile.name}.json`
+                );
+              }}
+            >
+              <GetApp fontSize="small" />
+            </IconButton>
+          )}
+        </Grid>
+        {results && <ReactJson src={results} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />}
+        {patientFile && <h2>Patient Bundle:</h2>}
+        {patientFile && (
+          <ReactJson src={patientFile} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />
+        )}
+      </>
+    );
+  };
 
   const displayHTMLResults = () => {
     return (
       <Grid item xs>
-              {results &&
-                htmls &&
-                htmls.map(html => {
-                  return (
-                    <div key={html.groupId} className={classes.highlightedMarkup}>
-                      <h2>HTML:</h2>
-                      {parse(html.html)}
-                    </div>
-                  );
-                })}
-            </Grid>
-    )
-  }
+        {results &&
+          htmls &&
+          htmls.map(html => {
+            return (
+              <div key={html.groupId} className={classes.highlightedMarkup}>
+                <h2>HTML:</h2>
+                {parse(html.html)}
+              </div>
+            );
+          })}
+      </Grid>
+    );
+  };
 
   const displayTabularResults = () => {
     return (
       <Grid container item xs={12} direction="row" justify="center" alignItems="center">
-          {
-            fhirpath.evaluate(results, 'MeasureReport.group').map((group: R4.IMeasureReport_Group) => {
-              const id = results ? fhirpath.evaluate(results, 'MeasureReport.subject.reference')[0].split('/') : '';
-              return (
-                <Grid container item xs={12} direction="column" justify="center" alignItems="center" key={group.id}>
-                  <h2>{group.id} Population Results</h2>
-                  <PopulationResults key={group.id} results={group} id={id} />
-                </Grid>
-              );
-          })}
-        </Grid>
-    )
-  }
+        {fhirpath.evaluate(results, 'MeasureReport.group').map((group: R4.IMeasureReport_Group) => {
+          const id = results ? fhirpath.evaluate(results, 'MeasureReport.subject.reference')[0].split('/') : '';
+          return (
+            <Grid container item xs={12} direction="column" justify="center" alignItems="center" key={group.id}>
+              <h2>{group.id} Population Results</h2>
+              <PopulationResults key={group.id} results={group} id={id} />
+            </Grid>
+          );
+        })}
+      </Grid>
+    );
+  };
 
   const displayAccordionResults = () => {
     return (
       <>
-      {results &&
-        detectedIssues.map((issue: R4.IDetectedIssue, index: number) => {
-          const detectedIssueId = fhirpath.evaluate(issue, 'id');
-          return (
-            <Grid
-              container
-              item
-              xs={12}
-              direction="column"
-              justify="center"
-              alignItems="center"
-              key={detectedIssueId}
-            >
-              <h3>Detected Issue {index + 1}</h3>
-              <h4>{fhirpath.evaluate(issue, 'contained.GuidanceResponse').length} Guidance Response(s)</h4>
-              <DetectedIssueResources detectedIssue={issue} />
-            </Grid>
-          );
-        })}
+        {results &&
+          detectedIssues.map((issue: R4.IDetectedIssue, index: number) => {
+            const detectedIssueId = fhirpath.evaluate(issue, 'id');
+            return (
+              <Grid
+                container
+                item
+                xs={12}
+                direction="column"
+                justify="center"
+                alignItems="center"
+                key={detectedIssueId}
+              >
+                <h3>Detected Issue {index + 1}</h3>
+                <h4>{fhirpath.evaluate(issue, 'contained.GuidanceResponse').length} Guidance Response(s)</h4>
+                <DetectedIssueResources detectedIssue={issue} />
+              </Grid>
+            );
+          })}
       </>
-    )
-  }
+    );
+  };
 
   const shouldDisplayHTML = () => {
     return htmls.length > 0;
-  }
+  };
 
   const shouldDisplayAccordion = () => {
-    return outputType === "gapsInCare";
-  }
+    return outputType === 'gapsInCare';
+  };
 
-  const shouldDisplayTabular = () => {    
-    return outputType === "measureReports" && calculationOptions.reportType === 'individual';
-  }
+  const shouldDisplayTabular = () => {
+    return outputType === 'measureReports' && calculationOptions.reportType === 'individual';
+  };
 
   const shouldDisplayTabs = () => {
-    return (shouldDisplayHTML() || shouldDisplayAccordion() || shouldDisplayTabular());
-  }
-  
+    return shouldDisplayHTML() || shouldDisplayAccordion() || shouldDisplayTabular();
+  };
+
   return (
     <Grid container xs={12} direction="column" spacing={2}>
-      <h2>Results:</h2> {
-        shouldDisplayTabs() ? 
-        <TabContext value={value}> 
+      <h2>Results:</h2>{' '}
+      {shouldDisplayTabs() ? (
+        <TabContext value={value}>
           <AppBar position="static">
-            <Tabs TabIndicatorProps={{style: {background:'white'}}} aria-label="results tabs" onChange = {handleChange} value = {value} indicatorColor="primary" centered>
-              <Tab style={style} label="Raw JSON" value='0' />
-              {
-                shouldDisplayHTML() && <Tab style={style} label="Highlighted HTML" value='1' />
-              } 
-              {
-                shouldDisplayTabular() && <Tab style={style} label="Tabular" value='2' />
-              }
-              {
-                shouldDisplayAccordion() && <Tab style={style} label="Accordion" value='3' />
-              }
+            <Tabs
+              TabIndicatorProps={{ style: { background: 'white' } }}
+              aria-label="results tabs"
+              onChange={handleChange}
+              value={value}
+              indicatorColor="primary"
+              centered
+            >
+              <Tab style={style} label="Raw JSON" value="0" />
+              {shouldDisplayHTML() && <Tab style={style} label="Highlighted HTML" value="1" />}
+              {shouldDisplayTabular() && <Tab style={style} label="Tabular" value="2" />}
+              {shouldDisplayAccordion() && <Tab style={style} label="Accordion" value="3" />}
             </Tabs>
           </AppBar>
 
-          <TabPanel value = '0'>
-            {displayJSONResults()}
-          </TabPanel>
-          {shouldDisplayHTML() && 
-            <TabPanel value = '1'> 
-              {displayHTMLResults()}
-            </TabPanel>
-          }
-          {shouldDisplayTabular() && 
-            <TabPanel value = '2'>
-              {displayTabularResults()}
-            </TabPanel>
-          }
-          {shouldDisplayAccordion() && 
-            <TabPanel value = '3'>
-              {displayAccordionResults()}
-            </TabPanel>}
-          </TabContext>
-        : displayJSONResults()
-      } 
+          <TabPanel value="0">{displayJSONResults()}</TabPanel>
+          {shouldDisplayHTML() && <TabPanel value="1">{displayHTMLResults()}</TabPanel>}
+          {shouldDisplayTabular() && <TabPanel value="2">{displayTabularResults()}</TabPanel>}
+          {shouldDisplayAccordion() && <TabPanel value="3">{displayAccordionResults()}</TabPanel>}
+        </TabContext>
+      ) : (
+        displayJSONResults()
+      )}
     </Grid>
-    
   );
 };
 

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -46,44 +46,38 @@ const Results: React.FC<Props> = ({ measureFile, patientFile, htmls }) => {
     setValue(newValue);
   }
 
-  return (
-    <Grid container xs={12} direction="column" spacing={2}>
-      <h2>Results:</h2>
-      <TabContext value={value}>
-        <AppBar position="static">
-          <Tabs aria-label="results tabs" onChange = {handleChange} value = {value} indicatorColor="primary" textColor="primary" centered>
-            <Tab style={style} label="Raw JSON" value='0'/>
-            <Tab style={style} label="Highlighted HTML" value='1' />
-            <Tab style={style} label="Tabular" value='2' />
-            <Tab style={style} label="Accordion" value='3' />
-          </Tabs>
-        </AppBar>
-        <TabPanel value = '0'>
-          <Grid container item xs direction="row">
-            {results && <h2>JSON:</h2>}
-            {results && (
-              <IconButton
-                onClick={() => {
-                  fileDownload(
-                    JSON.stringify(results, null, 2),
-                    measureFile.name?.includes('.json')
-                      ? `results-${measureFile.name}`
-                      : `results-${measureFile.name}.json`
-                  );
-                }}
-              >
-                <GetApp fontSize="small" />
-              </IconButton>
-            )}
-          </Grid>
-          {results && <ReactJson src={results} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />}
-          {patientFile && <h2>Patient Bundle:</h2>}
-          {patientFile && (
-            <ReactJson src={patientFile} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />
-          )}
-        </TabPanel>
-        <TabPanel value = '1'> 
-          <Grid item xs>
+  const displayJSONResults = () => {
+    return (
+    <>
+    <Grid container item xs direction="row">
+      {results && <h2>JSON:</h2>}
+      {results && (
+        <IconButton
+          onClick={() => {
+            fileDownload(
+              JSON.stringify(results, null, 2),
+              measureFile.name?.includes('.json')
+                ? `results-${measureFile.name}`
+                : `results-${measureFile.name}.json`
+            );
+          }}
+        >
+          <GetApp fontSize="small" />
+        </IconButton>
+      )}
+    </Grid>
+    {results && <ReactJson src={results} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />}
+    {patientFile && <h2>Patient Bundle:</h2>}
+    {patientFile && (
+      <ReactJson src={patientFile} enableClipboard={true} theme="shapeshifter:inverted" collapsed={2} />
+    )}
+    </>
+    )
+  }
+
+  const displayHTMLResults = () => {
+    return (
+      <Grid item xs>
               {results &&
                 htmls &&
                 htmls.map(html => {
@@ -95,44 +89,108 @@ const Results: React.FC<Props> = ({ measureFile, patientFile, htmls }) => {
                   );
                 })}
             </Grid>
-        </TabPanel>
-        <TabPanel value = '2'>
-          <Grid container item xs={12} direction="row" justify="center" alignItems="center">
-            {outputType === 'measureReports' &&
-              calculationOptions.reportType === 'individual' &&
-              fhirpath.evaluate(results, 'MeasureReport.group').map((group: R4.IMeasureReport_Group) => {
-                const id = results ? fhirpath.evaluate(results, 'MeasureReport.subject.reference')[0].split('/') : '';
-                return (
-                  <Grid container item xs={12} direction="column" justify="center" alignItems="center" key={group.id}>
-                    <h2>{group.id} Population Results</h2>
-                    <PopulationResults key={group.id} results={group} id={id} />
-                  </Grid>
-                );
-            })}
-          </Grid>
-        </TabPanel>
-        <TabPanel value = '3'>
-          {results &&
-              detectedIssues.map((issue: R4.IDetectedIssue, index: number) => {
-                const detectedIssueId = fhirpath.evaluate(issue, 'id');
-                return (
-                  <Grid
-                    container
-                    item
-                    xs={12}
-                    direction="column"
-                    justify="center"
-                    alignItems="center"
-                    key={detectedIssueId}
-                  >
-                    <h3>Detected Issue {index + 1}</h3>
-                    <h4>{fhirpath.evaluate(issue, 'contained.GuidanceResponse').length} Guidance Response(s)</h4>
-                    <DetectedIssueResources detectedIssue={issue} />
-                  </Grid>
-                );
-              })}
-        </TabPanel>
-      </TabContext>
+    )
+  }
+
+  const displayTabularResults = () => {
+    return (
+      <Grid container item xs={12} direction="row" justify="center" alignItems="center">
+          {
+            fhirpath.evaluate(results, 'MeasureReport.group').map((group: R4.IMeasureReport_Group) => {
+              const id = results ? fhirpath.evaluate(results, 'MeasureReport.subject.reference')[0].split('/') : '';
+              return (
+                <Grid container item xs={12} direction="column" justify="center" alignItems="center" key={group.id}>
+                  <h2>{group.id} Population Results</h2>
+                  <PopulationResults key={group.id} results={group} id={id} />
+                </Grid>
+              );
+          })}
+        </Grid>
+    )
+  }
+
+  const displayAccordionResults = () => {
+    return (
+      <>
+      {results &&
+        detectedIssues.map((issue: R4.IDetectedIssue, index: number) => {
+          const detectedIssueId = fhirpath.evaluate(issue, 'id');
+          return (
+            <Grid
+              container
+              item
+              xs={12}
+              direction="column"
+              justify="center"
+              alignItems="center"
+              key={detectedIssueId}
+            >
+              <h3>Detected Issue {index + 1}</h3>
+              <h4>{fhirpath.evaluate(issue, 'contained.GuidanceResponse').length} Guidance Response(s)</h4>
+              <DetectedIssueResources detectedIssue={issue} />
+            </Grid>
+          );
+        })}
+      </>
+    )
+  }
+
+  const shouldDisplayHTML = () => {
+    return htmls.length > 0;
+  }
+
+  const shouldDisplayAccordion = () => {
+    return outputType === "gapsInCare";
+  }
+
+  const shouldDisplayTabular = () => {    
+    return outputType === "measureReports" && calculationOptions.reportType === 'individual';
+  }
+
+  const shouldDisplayTabs = () => {
+    return (shouldDisplayHTML() || shouldDisplayAccordion() || shouldDisplayTabular());
+  }
+  
+  return (
+    <Grid container xs={12} direction="column" spacing={2}>
+      <h2>Results:</h2> {
+        shouldDisplayTabs() ? 
+        <TabContext value={value}> 
+          <AppBar position="static">
+            <Tabs TabIndicatorProps={{style: {background:'white'}}} aria-label="results tabs" onChange = {handleChange} value = {value} indicatorColor="primary" centered>
+              <Tab style={style} label="Raw JSON" value='0' />
+              {
+                shouldDisplayHTML() && <Tab style={style} label="Highlighted HTML" value='1' />
+              } 
+              {
+                shouldDisplayTabular() && <Tab style={style} label="Tabular" value='2' />
+              }
+              {
+                shouldDisplayAccordion() && <Tab style={style} label="Accordion" value='3' />
+              }
+            </Tabs>
+          </AppBar>
+
+          <TabPanel value = '0'>
+            {displayJSONResults()}
+          </TabPanel>
+          {shouldDisplayHTML() && 
+            <TabPanel value = '1'> 
+              {displayHTMLResults()}
+            </TabPanel>
+          }
+          {shouldDisplayTabular() && 
+            <TabPanel value = '2'>
+              {displayTabularResults()}
+            </TabPanel>
+          }
+          {shouldDisplayAccordion() && 
+            <TabPanel value = '3'>
+              {displayAccordionResults()}
+            </TabPanel>}
+          </TabContext>
+        : displayJSONResults()
+      } 
     </Grid>
     
   );

--- a/src/components/ResultsPage.tsx
+++ b/src/components/ResultsPage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { htmlsState, measureFileState, patientFileState } from '../state';
-import { useHistory } from 'react-router-dom';
-import Button from '@material-ui/core/Button';
+// import { useHistory } from 'react-router-dom';
+// import Button from '@material-ui/core/Button';
 import Results from './Results';
 import { makeStyles } from '@material-ui/styles';
 
@@ -17,12 +17,12 @@ const ResultsPage: React.FC = () => {
   const htmls = useRecoilValue(htmlsState);
   const measureFile = useRecoilValue(measureFileState);
   const patientFile = useRecoilValue(patientFileState);
-  const history = useHistory();
+  // const history = useHistory();
   return (
     <div className={styles.root}>
-      <Button variant="contained" onClick={() => history.push('/fqm-execution-demo')}>
+      {/* <Button variant="contained" onClick={() => history.push('/fqm-execution-demo')}>
         Home
-      </Button>
+      </Button> */}
       <Results measureFile={measureFile} patientFile={patientFile} htmls={htmls} />
     </div>
   );


### PR DESCRIPTION
### Summary
Depending on which output type is desired, multiple output views may appear on the results page. In the past, these output views all appeared on the results page in a Grid. Now, the output views appear on the results page in a tabular form so that we have easier navigation of our results.

### New behavior
After choosing measure/patient bundles, output type, calculation type, report type, and measurement period, the user will press the "Calculate" button and arrive at the results page, which now has a tab bar if the combination of output type, calculation type, and report type calls for more than one output view. If the desired output type only calls for JSON output (which is the case for raw results, for example), then the tab bar does not appear on the results page. The tabs are generated dynamically and they depend on what combination of output type, calculation type, and report type is selected.

### Code changes
Changes were made to the `src/components/Results/Results.tsx` file to reflect the addition of tabs. The previous code for the different output views were put into separate functions called `displayJSONResults()`, `displayHTMLResults()`, `displayTabularResults()`, and `displayAccordionResults()`. Boolean functions were created to check which tabs should appear in the results page. A ternary operator was used to decide whether to render the tab bar or to simply show the JSON output.

### Testing guidance
First, use the Connectathon Repository to select a measure bundle and patient bundle (EXM130, for example), or upload the appropriate bundle files from your local machine. Then, for each combination of valid output type, calculation type, and report type, check that the correct tabs appear in the results page, or that the tab bar does _not_ appear in the case that only the JSON output should be returned. The intended output views are as follows:

- Raw Results: JSON only (no tab bar)
- Detailed Results: either JSON only (no tab bar) or JSON and HTML (if checked)
- Measure Reports: JSON only (no tab bar) for "summary", JSON, Tabular, and HTML (if checked) for "individual"
- Gaps in Care: JSON, Accordion, and HTML (if checked)

Note: For Measure Reports, it is possible to check the HTML box and then select "summary" afterwards, in which the HTML box stays checked but is grayed out. This causes the HTML tab to appear in the tab bar, but no HTML output is provided on the results page. We believe this may be a bug, generating an HTML array when it should not be.
