### PR TITLE
Disabled HTML for Summary MeasureReports, Disabled Report Type for non-MeasureReports Output Type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,7 +120,7 @@ export default function App() {
         const mrResults = await Calculator.calculateMeasureReports(measureFile.content, [patientFile.content], options);
         const mrs = mrResults.results;
 
-        if (calculationOptions.calculateHTML) {
+        if (calculationOptions.calculateHTML && calculationOptions.reportType === 'individual') {
           const htmls: HTML[] = (Array.isArray(mrs) ? mrs : [mrs]).map(m => ({
             groupId: m.id || '',
             html: m.text?.div || ''

--- a/src/components/CalculationOptions/CalculationOptions.tsx
+++ b/src/components/CalculationOptions/CalculationOptions.tsx
@@ -16,21 +16,38 @@ function CalculationOptionsButtons() {
     });
   };
 
+  const shouldCheckSDE = () => {
+    return (
+      outputType !== 'rawResults' && calculationOptions.reportType === 'individual' && calculationOptions.calculateSDEs
+    );
+  };
+
+  const shouldDisableSDE = () => {
+    return (
+      outputType === 'rawResults' || (outputType === 'measureReports' && calculationOptions.reportType === 'summary')
+    );
+  };
+
+  const shouldCheckHTML = () => {
+    return (
+      outputType !== 'rawResults' && calculationOptions.reportType !== 'summary' && calculationOptions.calculateHTML
+    );
+  };
+
+  const shouldDisableHTML = () => {
+    return (
+      outputType === 'rawResults' || (outputType === 'measureReports' && calculationOptions.reportType === 'summary')
+    );
+  };
+
   return (
     <FormGroup>
       <FormControlLabel
         control={
           <Checkbox
-            checked={
-              outputType !== 'rawResults' &&
-              calculationOptions.reportType !== 'summary' &&
-              calculationOptions.calculateSDEs
-            }
+            checked={shouldCheckSDE()}
             onChange={handleChange}
-            disabled={
-              outputType === 'rawResults' ||
-              (outputType === 'measureReports' && calculationOptions.reportType === 'summary')
-            }
+            disabled={shouldDisableSDE()}
             name="calculateSDEs"
             color="primary"
           />
@@ -40,16 +57,9 @@ function CalculationOptionsButtons() {
       <FormControlLabel
         control={
           <Checkbox
-            checked={
-              outputType !== 'rawResults' &&
-              calculationOptions.reportType !== 'summary' &&
-              calculationOptions.calculateHTML
-            }
+            checked={shouldCheckHTML()}
             onChange={handleChange}
-            disabled={
-              outputType === 'rawResults' ||
-              (outputType === 'measureReports' && calculationOptions.reportType === 'summary')
-            }
+            disabled={shouldDisableHTML()}
             name="calculateHTML"
             color="primary"
           />

--- a/src/components/CalculationOptions/CalculationOptions.tsx
+++ b/src/components/CalculationOptions/CalculationOptions.tsx
@@ -21,7 +21,11 @@ function CalculationOptionsButtons() {
       <FormControlLabel
         control={
           <Checkbox
-            checked={outputType !== 'rawResults' && calculationOptions.calculateSDEs}
+            checked={
+              outputType !== 'rawResults' &&
+              calculationOptions.reportType !== 'summary' &&
+              calculationOptions.calculateSDEs
+            }
             onChange={handleChange}
             disabled={
               outputType === 'rawResults' ||
@@ -36,7 +40,11 @@ function CalculationOptionsButtons() {
       <FormControlLabel
         control={
           <Checkbox
-            checked={outputType !== 'rawResults' && calculationOptions.calculateHTML}
+            checked={
+              outputType !== 'rawResults' &&
+              calculationOptions.reportType !== 'summary' &&
+              calculationOptions.calculateHTML
+            }
             onChange={handleChange}
             disabled={
               outputType === 'rawResults' ||

--- a/src/components/CalculationOptions/OutputType.tsx
+++ b/src/components/CalculationOptions/OutputType.tsx
@@ -11,7 +11,7 @@ function OutputTypeButtons() {
   const [calculationOptions, setCalculationOptions] = useRecoilState(calculationOptionsState);
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = (event.target as HTMLInputElement).value;
-    if (value === 'gapsInCare') {
+    if (value === 'gapsInCare' || value === 'detailedResults') {
       setCalculationOptions({ ...calculationOptions, reportType: 'individual' });
     }
     setOutputType(value);

--- a/src/components/CalculationOptions/ReportType.tsx
+++ b/src/components/CalculationOptions/ReportType.tsx
@@ -23,14 +23,14 @@ function ReportTypeButtons() {
         <FormControlLabel
           control={<Radio color="primary" />}
           value="individual"
-          checked={calculationOptions.reportType === 'individual' ?? false}
+          checked={outputType === 'measureReports' && (calculationOptions.reportType === 'individual' ?? false)}
           label="Individual"
           disabled={outputType !== 'measureReports'}
         />
         <FormControlLabel
           control={<Radio color="primary" />}
           value="summary"
-          checked={calculationOptions.reportType === 'summary' ?? false}
+          checked={outputType === 'measureReports' && (calculationOptions.reportType === 'summary' ?? false)}
           label="Summary"
           disabled={outputType !== 'measureReports'}
         />


### PR DESCRIPTION
### Summary
Minor changes were made to the frontend code so that the HTML header no longer appears when the "Summary" Report Type is chosen for Measure Reports. Also, conditional logic was added so that the checkboxes for "Calculation Options" and the radio buttons for "Report Type" are deselected when they are no longer relevant to the selected Output Type.

### New behavior
If the user checks the "Calculate SDEs" or "Calculate HTML" checkboxes and _then_ selects an output type/report type that does not allow for the calculation of SDEs or HTML, those checkboxes will be deselected and the HTML headline will not appear on the results page. Similarly, if the user selects an output type that does not require a report type to be selected, the radio buttons for report type will be deselected.

### Code changes
These changes are reflected in `src/App.tsx` by adding an additional condition that checks for an "Individual" report type before calculating the HTML for Measure Reports. Previously, the code would run for "Summary" report type, which caused the demo to believe HTML was selected and made its headline appear on the results page. Changes were made to `src/components/CalculationOptions/CalculationOptions.tsx` to add logic for the circumstances under which the checkboxes should be allowed to be checked. Lastly, code was added to `src/components/CalculationOptions/ReportType.tsx` to add logic for the circumstances under which the radio buttons for report type should be allowed to be checked.

### Testing guidance
Run the demo app with the EXM130 measure/patient bundle, either through the Connectathon repository or by uploading from your local machine. Try selecting one of the Calculation Options and/or one of the Report Types, and then select an Output Type that does not call for these (good examples include Raw Results and Measure Reports when the Report Type is equal to Summary). Then, for Measure Reports with Report Type of Summary, go through to the results page and check that the HTML headline was not generated.