### PR TITLE
Clean visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16328,8 +16328,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Accordion, AccordionSummary, AccordionDetails, Grid, Typography } from '@material-ui/core';
+import { Accordion, AccordionDetails, Grid, Link, Typography, withStyles } from '@material-ui/core';
+import MuiAccordionSummary from '@material-ui/core/AccordionSummary';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { Enums } from 'fqm-execution';
 import fhirpath from 'fhirpath';
@@ -7,6 +8,14 @@ import fhirpath from 'fhirpath';
 interface Props {
   detectedIssue: R4.IDetectedIssue;
 }
+
+const AccordionSummary = withStyles({
+  root: {
+    backgroundColor: 'rgba(0, 0, 0, .03)',
+    borderBottom: '1px solid rgba(0, 0, 0, .125)'
+  },
+  expanded: {}
+})(MuiAccordionSummary);
 
 const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
   const guidanceResponses = fhirpath.evaluate(detectedIssue, 'contained.GuidanceResponse');
@@ -29,6 +38,7 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
         const endDate = new Date(fhirpath.evaluate(response, 'dataRequirement.dateFilter.valuePeriod.end'));
         const codeFilterPath1 = fhirpath.evaluate(response, 'dataRequirement.codeFilter.path[0]');
         const codeFilterPath2 = fhirpath.evaluate(response, 'dataRequirement.codeFilter.path[1]');
+        const link = 'http://hl7.org/fhir/';
 
         return (
           <Accordion key={guidanceResponseId}>
@@ -46,20 +56,33 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                   <Grid item xs>
                     <h4>Requirements:</h4>
                   </Grid>
-                  <Grid item xs>
-                    Type: {fhirpath.evaluate(response, 'dataRequirement.type')}
+                  <Grid item xs direction="row">
+                    <Grid item xs>
+                      Type:{' '}
+                      <Link href={link.concat(fhirpath.evaluate(response, 'dataRequirement.type'))}>
+                        {fhirpath.evaluate(response, 'dataRequirement.type')}
+                      </Link>
+                    </Grid>
                   </Grid>
                   <Grid item xs>
                     <h4>Codes:</h4>
-                    <h5>{codeFilterPath1[0].charAt(0).toUpperCase()}{codeFilterPath1[0].slice(1)}:</h5>
+                    <h5>
+                      {codeFilterPath1[0].charAt(0).toUpperCase()}
+                      {codeFilterPath1[0].slice(1)}:
+                    </h5>
                   </Grid>
                   <Grid item xs>
-                    <Typography style={{ overflowWrap: 'break-word' }}> 
-                      {fhirpath.evaluate(response, 'dataRequirement.codeFilter.valueSet')}
+                    <Typography style={{ overflowWrap: 'break-word' }}>
+                      <Link href={fhirpath.evaluate(response, 'dataRequirement.codeFilter.valueSet')}>
+                        {fhirpath.evaluate(response, 'dataRequirement.codeFilter.valueSet')}
+                      </Link>
                     </Typography>
                   </Grid>
                   <Grid item xs>
-                  <h5>{codeFilterPath2[0].charAt(0).toUpperCase()}{codeFilterPath2[0].slice(1)}:</h5>
+                    <h5>
+                      {codeFilterPath2[0].charAt(0).toUpperCase()}
+                      {codeFilterPath2[0].slice(1)}:
+                    </h5>
                   </Grid>
                   <Grid item xs>
                     {fhirpath.evaluate(response, 'dataRequirement.codeFilter.code.code').map((code: string) => {
@@ -71,27 +94,23 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                     })}
                   </Grid>
                   <Grid item xs>
-                    <h5>Dates:</h5>
-                  </Grid>
-                  <Grid item xs>
-                    {fhirpath.evaluate(response, 'dataRequirement.dateFilter.path')}
+                    <h4>Dates:</h4>
+                    <h5>{fhirpath.evaluate(response, 'dataRequirement.dateFilter.path')}:</h5>
                   </Grid>
                   <Grid item xs>
                     {startDate.toDateString()}-{endDate.toDateString()}
                   </Grid>
                 </Grid>
-                <Grid container xs direction="column" justify="flex-start" alignContent="flex-start">
+                <Grid container xs direction="column">
                   <Grid item xs>
                     <h4>Reason(s):</h4>
-                  </Grid>
-                  <Grid item xs>
                     {fhirpath.evaluate(response, 'reasonCode').map((reason: R4.IGuidanceResponse) => {
-                        return (
-                          <Grid item xs key={fhirpath.evaluate(reason, 'coding.code')}>
-                            - {fhirpath.evaluate(reason, 'coding.code')} ({fhirpath.evaluate(reason, 'coding.display')})
-                          </Grid>
-                        );
-                      })}
+                      return (
+                        <Grid item xs key={fhirpath.evaluate(reason, 'coding.code')}>
+                          - {fhirpath.evaluate(reason, 'coding.code')} ({fhirpath.evaluate(reason, 'coding.display')})
+                        </Grid>
+                      );
+                    })}
                   </Grid>
                 </Grid>
               </Grid>

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -34,11 +34,12 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
     <div>
       {guidanceResponseArray.map((response: R4.IGuidanceResponse, index: number) => {
         const guidanceResponseId = fhirpath.evaluate(response, 'id');
+        const codeFilters = fhirpath.evaluate(response, 'dataRequirement.codeFilter');
         const startDate = new Date(fhirpath.evaluate(response, 'dataRequirement.dateFilter.valuePeriod.start'));
         const endDate = new Date(fhirpath.evaluate(response, 'dataRequirement.dateFilter.valuePeriod.end'));
-        const codeFilterPath1 = fhirpath.evaluate(response, 'dataRequirement.codeFilter.path[0]');
-        const codeFilterPath2 = fhirpath.evaluate(response, 'dataRequirement.codeFilter.path[1]');
         const link = 'http://hl7.org/fhir/';
+        const valueSetObj = codeFilters.find((cf: any) => cf.valueSet);
+        const codeFilterArray = codeFilters.filter((cf: any) => !!!cf.valueSet);
 
         return (
           <Accordion key={guidanceResponseId}>
@@ -56,39 +57,37 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                   <Grid item xs>
                     <h4>Requirements:</h4>
                   </Grid>
-                  <Grid item xs direction="row">
-                    <Grid item xs>
-                      Type:{' '}
-                      <Link href={link.concat(fhirpath.evaluate(response, 'dataRequirement.type'))}>
-                        {fhirpath.evaluate(response, 'dataRequirement.type')}
-                      </Link>
-                    </Grid>
+                  <Grid item xs>
+                    Type:{' '}
+                    <Link href={link.concat(fhirpath.evaluate(response, 'dataRequirement.type'))}>
+                      {fhirpath.evaluate(response, 'dataRequirement.type')}
+                    </Link>
                   </Grid>
                   <Grid item xs>
                     <h4>Codes:</h4>
-                    <h5>
-                      {codeFilterPath1[0].charAt(0).toUpperCase()}
-                      {codeFilterPath1[0].slice(1)}:
-                    </h5>
+                    <h5>{fhirpath.evaluate(valueSetObj, 'path')}:</h5>
                   </Grid>
                   <Grid item xs>
                     <Typography style={{ overflowWrap: 'break-word' }}>
-                      <Link href={fhirpath.evaluate(response, 'dataRequirement.codeFilter.valueSet')}>
-                        {fhirpath.evaluate(response, 'dataRequirement.codeFilter.valueSet')}
+                      <Link href={fhirpath.evaluate(valueSetObj, 'valueSet')}>
+                        {fhirpath.evaluate(valueSetObj, 'valueSet')}
                       </Link>
                     </Typography>
                   </Grid>
                   <Grid item xs>
-                    <h5>
-                      {codeFilterPath2[0].charAt(0).toUpperCase()}
-                      {codeFilterPath2[0].slice(1)}:
-                    </h5>
-                  </Grid>
-                  <Grid item xs>
-                    {fhirpath.evaluate(response, 'dataRequirement.codeFilter.code.code').map((code: string) => {
+                    {codeFilterArray.map((cf: any) => {
                       return (
-                        <Grid item xs key={code}>
-                          - {code}
+                        <Grid item xs key={fhirpath.evaluate(cf, 'path')[0]}>
+                          <h5>{fhirpath.evaluate(cf, 'path')[0]}:</h5>
+                          <Grid item xs>
+                            {fhirpath.evaluate(cf, 'code.code').map((code: string) => {
+                              return (
+                                <Grid item xs key={code}>
+                                  - {code}
+                                </Grid>
+                              );
+                            })}
+                          </Grid>
                         </Grid>
                       );
                     })}
@@ -98,16 +97,18 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                     <h5>{fhirpath.evaluate(response, 'dataRequirement.dateFilter.path')}:</h5>
                   </Grid>
                   <Grid item xs>
-                    {startDate.toDateString()}-{endDate.toDateString()}
+                    {startDate.toDateString()} - {endDate.toDateString()}
                   </Grid>
                 </Grid>
-                <Grid container xs direction="column">
+                <Grid container item xs direction="column">
                   <Grid item xs>
                     <h4>Reason(s):</h4>
                     {fhirpath.evaluate(response, 'reasonCode').map((reason: R4.IGuidanceResponse) => {
+                      const code = fhirpath.evaluate(reason, 'coding.code');
+                      const display = fhirpath.evaluate(reason, 'coding.display');
                       return (
-                        <Grid item xs key={fhirpath.evaluate(reason, 'coding.code')}>
-                          - {fhirpath.evaluate(reason, 'coding.code')} ({fhirpath.evaluate(reason, 'coding.display')})
+                        <Grid item xs key={code}>
+                          - {code} ({display})
                         </Grid>
                       );
                     })}

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -35,8 +35,6 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
       {guidanceResponseArray.map((response: R4.IGuidanceResponse, index: number) => {
         const guidanceResponseId = fhirpath.evaluate(response, 'id');
         const codeFilters = fhirpath.evaluate(response, 'dataRequirement.codeFilter');
-        const startDate = new Date(fhirpath.evaluate(response, 'dataRequirement.dateFilter.valuePeriod.start'));
-        const endDate = new Date(fhirpath.evaluate(response, 'dataRequirement.dateFilter.valuePeriod.end'));
         const link = 'http://hl7.org/fhir/';
         const valueSetObj = codeFilters.find((cf: any) => cf.valueSet);
         const codeFilterArray = codeFilters.filter((cf: any) => !!!cf.valueSet);
@@ -76,9 +74,10 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                   </Grid>
                   <Grid item xs>
                     {codeFilterArray.map((cf: any) => {
+                      const path = fhirpath.evaluate(cf, 'path');
                       return (
-                        <Grid item xs key={fhirpath.evaluate(cf, 'path')[0]}>
-                          <h5>{fhirpath.evaluate(cf, 'path')[0]}:</h5>
+                        <Grid item xs key={path}>
+                          <h5>{path}:</h5>
                           <Grid item xs>
                             {fhirpath.evaluate(cf, 'code.code').map((code: string) => {
                               return (
@@ -94,10 +93,19 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                   </Grid>
                   <Grid item xs>
                     <h4>Dates:</h4>
-                    <h5>{fhirpath.evaluate(response, 'dataRequirement.dateFilter.path')}:</h5>
-                  </Grid>
-                  <Grid item xs>
-                    {startDate.toDateString()} - {endDate.toDateString()}
+                    {fhirpath.evaluate(response, 'dataRequirement.dateFilter').map((df: any) => {
+                      const path = fhirpath.evaluate(df, 'path');
+                      const startDate = new Date(fhirpath.evaluate(df, 'valuePeriod.start'));
+                      const endDate = new Date(fhirpath.evaluate(df, 'valuePeriod.end'));
+                      return (
+                        <Grid item xs key={path}>
+                          <h5>{fhirpath.evaluate(df, 'path')}:</h5>
+                          <Grid item xs>
+                            {startDate.toDateString()} - {endDate.toDateString()}
+                          </Grid>
+                        </Grid>
+                      );
+                    })}
                   </Grid>
                 </Grid>
                 <Grid container item xs direction="column">

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -25,6 +25,11 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
     <div>
       {guidanceResponseArray.map((response: R4.IGuidanceResponse, index: number) => {
         const guidanceResponseId = fhirpath.evaluate(response, 'id');
+        const startDate = new Date(fhirpath.evaluate(response, 'dataRequirement.dateFilter.valuePeriod.start'));
+        const endDate = new Date(fhirpath.evaluate(response, 'dataRequirement.dateFilter.valuePeriod.end'));
+        const codeFilterPath1 = fhirpath.evaluate(response, 'dataRequirement.codeFilter.path[0]');
+        const codeFilterPath2 = fhirpath.evaluate(response, 'dataRequirement.codeFilter.path[1]');
+
         return (
           <Accordion key={guidanceResponseId}>
             <AccordionSummary>
@@ -36,63 +41,57 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
               </Grid>
             </AccordionSummary>
             <AccordionDetails>
-              <Grid container item xs direction="row">
+              <Grid container item xs direction="row" spacing={2}>
                 <Grid container item xs={6} direction="column">
                   <Grid item xs>
-                    <h4>dataRequirement:</h4>
+                    <h4>Requirements:</h4>
                   </Grid>
                   <Grid item xs>
-                    type: {fhirpath.evaluate(response, 'dataRequirement.type')}
+                    Type: {fhirpath.evaluate(response, 'dataRequirement.type')}
                   </Grid>
                   <Grid item xs>
-                    <h5>codeFilter:</h5>
+                    <h4>Codes:</h4>
+                    <h5>{codeFilterPath1[0].charAt(0).toUpperCase()}{codeFilterPath1[0].slice(1)}:</h5>
                   </Grid>
-                  <Grid>path: {fhirpath.evaluate(response, 'dataRequirement.codeFilter.path[0]')}</Grid>
                   <Grid item xs>
-                    <Typography style={{ overflowWrap: 'break-word' }}>
-                      valueSet: {fhirpath.evaluate(response, 'dataRequirement.codeFilter.valueSet')}
+                    <Typography style={{ overflowWrap: 'break-word' }}> 
+                      {fhirpath.evaluate(response, 'dataRequirement.codeFilter.valueSet')}
                     </Typography>
                   </Grid>
                   <Grid item xs>
-                    path: {fhirpath.evaluate(response, 'dataRequirement.codeFilter.path[1]')}
+                  <h5>{codeFilterPath2[0].charAt(0).toUpperCase()}{codeFilterPath2[0].slice(1)}:</h5>
                   </Grid>
                   <Grid item xs>
                     {fhirpath.evaluate(response, 'dataRequirement.codeFilter.code.code').map((code: string) => {
                       return (
                         <Grid item xs key={code}>
-                          code: {code}
+                          - {code}
                         </Grid>
                       );
                     })}
                   </Grid>
                   <Grid item xs>
-                    <h5>dateFilter:</h5>
+                    <h5>Dates:</h5>
                   </Grid>
                   <Grid item xs>
-                    path: {fhirpath.evaluate(response, 'dataRequirement.dateFilter.path')}
+                    {fhirpath.evaluate(response, 'dataRequirement.dateFilter.path')}
                   </Grid>
                   <Grid item xs>
-                    valuePeriod:
-                  </Grid>
-                  <Grid item xs>
-                    start: {fhirpath.evaluate(response, 'dataRequirement.dateFilter.valuePeriod.start')}
-                  </Grid>
-                  <Grid item xs>
-                    end: {fhirpath.evaluate(response, 'dataRequirement.dateFilter.valuePeriod.end')}
+                    {startDate.toDateString()}-{endDate.toDateString()}
                   </Grid>
                 </Grid>
-                <Grid container item xs={6} direction="column">
+                <Grid container xs direction="column" justify="flex-start" alignContent="flex-start">
                   <Grid item xs>
-                    <h4>reasonCode:</h4>
+                    <h4>Reason(s):</h4>
                   </Grid>
                   <Grid item xs>
-                    system: {fhirpath.evaluate(response, 'reasonCode.coding.system')}
-                  </Grid>
-                  <Grid item xs>
-                    code: {fhirpath.evaluate(response, 'reasonCode.coding.code')}
-                  </Grid>
-                  <Grid item xs>
-                    display: {fhirpath.evaluate(response, 'reasonCode.coding.display')}
+                    {fhirpath.evaluate(response, 'reasonCode').map((reason: R4.IGuidanceResponse) => {
+                        return (
+                          <Grid item xs key={fhirpath.evaluate(reason, 'coding.code')}>
+                            - {fhirpath.evaluate(reason, 'coding.code')} ({fhirpath.evaluate(reason, 'coding.display')})
+                          </Grid>
+                        );
+                      })}
                   </Grid>
                 </Grid>
               </Grid>

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -37,7 +37,7 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
         const codeFilters = fhirpath.evaluate(response, 'dataRequirement.codeFilter');
         const link = 'http://hl7.org/fhir/';
         const valueSetObj = codeFilters.find((cf: any) => cf.valueSet);
-        const codeFilterArray = codeFilters.filter((cf: any) => !!!cf.valueSet);
+        const codeFilterArray = codeFilters.filter((cf: any) => !cf.valueSet);
 
         return (
           <Accordion key={guidanceResponseId}>
@@ -95,13 +95,14 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                     <h4>Dates:</h4>
                     {fhirpath.evaluate(response, 'dataRequirement.dateFilter').map((df: any) => {
                       const path = fhirpath.evaluate(df, 'path');
-                      const startDate = new Date(fhirpath.evaluate(df, 'valuePeriod.start'));
-                      const endDate = new Date(fhirpath.evaluate(df, 'valuePeriod.end'));
+                      const startDate = new Date(fhirpath.evaluate(df, 'valuePeriod.start')).toDateString();
+                      const endDate = new Date(fhirpath.evaluate(df, 'valuePeriod.end')).toDateString();
                       return (
                         <Grid item xs key={path}>
                           <h5>{fhirpath.evaluate(df, 'path')}:</h5>
                           <Grid item xs>
-                            {startDate.toDateString()} - {endDate.toDateString()}
+                            {startDate === 'Invalid Date' ? 'any' : startDate} -{' '}
+                            {endDate === 'Invalid Date' ? 'any' : endDate}
                           </Grid>
                         </Grid>
                       );


### PR DESCRIPTION
**Summary**
I made some styling changes to the Guidance Response accordion to clean up the visualization. Basically, the accordion details for each guidance response are structured differently so that it does not directly mirror the JSON output.

**New behavior**
- There is now a link for the type of requirement (for example, procedure links to hl7.org/fhir/procedure.
- There is now a link for the value set.
- There is no other behavior changes, only styling changes such as the color and border of the accordion summaries and the formats of the headers.

**Code changes**
- All changes were made in DetectedIssueResources.tsx

**Testing guidance**
This can be tested using EXM130 and the corresponding test-denom and choosing the gaps in care output.