### PR TITLE
Valueset name

### DIFF
--- a/src/components/Helpers/BundleHelpers.ts
+++ b/src/components/Helpers/BundleHelpers.ts
@@ -1,4 +1,5 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
+import fhirpath from 'fhirpath';
 
 export function findPatientInBundle(bundle: R4.IBundle, patientID: string): R4.IPatient | null {
   const e = bundle.entry?.find(e => e.resource?.id === patientID);
@@ -7,4 +8,9 @@ export function findPatientInBundle(bundle: R4.IBundle, patientID: string): R4.I
   } else {
     return e?.resource as R4.IPatient;
   }
+}
+
+export function findValueSetName(bundle: R4.IBundle, url: string): R4.IBundle_Entry {
+  const e = bundle.entry?.find(e => fhirpath.evaluate(e, 'resource.url')[0] === url);
+  return e as R4.IBundle_Entry;
 }

--- a/src/components/Helpers/BundleHelpers.ts
+++ b/src/components/Helpers/BundleHelpers.ts
@@ -1,16 +1,19 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import fhirpath from 'fhirpath';
 
 export function findPatientInBundle(bundle: R4.IBundle, patientID: string): R4.IPatient | null {
-  const e = bundle.entry?.find(e => e.resource?.id === patientID);
+  const e = bundle.entry?.find(e => e.resource?.resourceType === 'Patient' && e.resource?.id === patientID);
   if (e === undefined) {
     return null;
   } else {
-    return e?.resource as R4.IPatient;
+    return e.resource as R4.IPatient;
   }
 }
 
-export function findMeasureInBundle(bundle: R4.IBundle, url: string): R4.IBundle_Entry {
-  const e = bundle.entry?.find(e => fhirpath.evaluate(e, 'resource.url')[0] === url);
-  return e as R4.IBundle_Entry;
+export function findValueSetInBundle(bundle: R4.IBundle, url: string): R4.IValueSet | null {
+  const e = bundle.entry?.find(e => e.resource?.resourceType === 'ValueSet' && e.resource?.url === url);
+  if (e === undefined) {
+    return null;
+  } else {
+    return e.resource as R4.IValueSet;
+  }
 }

--- a/src/components/Helpers/BundleHelpers.ts
+++ b/src/components/Helpers/BundleHelpers.ts
@@ -10,7 +10,7 @@ export function findPatientInBundle(bundle: R4.IBundle, patientID: string): R4.I
   }
 }
 
-export function findValueSetName(bundle: R4.IBundle, url: string): R4.IBundle_Entry {
+export function findMeasureInBundle(bundle: R4.IBundle, url: string): R4.IBundle_Entry {
   const e = bundle.entry?.find(e => fhirpath.evaluate(e, 'resource.url')[0] === url);
   return e as R4.IBundle_Entry;
 }

--- a/src/components/Helpers/index.ts
+++ b/src/components/Helpers/index.ts
@@ -1,1 +1,1 @@
-export * from './PatientHelper';
+export * from './BundleHelpers';

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -3,6 +3,9 @@ import { Accordion, AccordionDetails, Grid, Link, Typography, withStyles } from 
 import MuiAccordionSummary from '@material-ui/core/AccordionSummary';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { Enums } from 'fqm-execution';
+import { measureFileState } from '../../state';
+import { useRecoilValue } from 'recoil';
+import { findValueSetName } from '../Helpers';
 import fhirpath from 'fhirpath';
 
 interface Props {
@@ -20,6 +23,7 @@ const AccordionSummary = withStyles({
 const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
   const guidanceResponses = fhirpath.evaluate(detectedIssue, 'contained.GuidanceResponse');
   const guidanceResponseArray: R4.IGuidanceResponse[] = [];
+  const measureFile = useRecoilValue(measureFileState);
 
   guidanceResponses.forEach((element: R4.IGuidanceResponse) => {
     const reasonCode = fhirpath.evaluate(element, 'reasonCode.coding.code')[0];
@@ -38,6 +42,10 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
         const link = 'http://hl7.org/fhir/';
         const valueSetObj = codeFilters.find((cf: any) => cf.valueSet);
         const codeFilterArray = codeFilters.filter((cf: any) => !cf.valueSet);
+        const measureResource =
+          measureFile.content === null
+            ? null
+            : findValueSetName(measureFile.content, fhirpath.evaluate(valueSetObj, 'valueSet')[0]);
 
         return (
           <Accordion key={guidanceResponseId}>
@@ -66,6 +74,7 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                     <h5>{fhirpath.evaluate(valueSetObj, 'path')}:</h5>
                   </Grid>
                   <Grid item xs>
+                    {fhirpath.evaluate(measureResource, 'resource.name')}:
                     <Typography style={{ overflowWrap: 'break-word' }}>
                       <Link href={fhirpath.evaluate(valueSetObj, 'valueSet')}>
                         {fhirpath.evaluate(valueSetObj, 'valueSet')}

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -5,7 +5,7 @@ import { R4 } from '@ahryman40k/ts-fhir-types';
 import { Enums } from 'fqm-execution';
 import { measureFileState } from '../../state';
 import { useRecoilValue } from 'recoil';
-import { findValueSetName } from '../Helpers';
+import { findMeasureInBundle } from '../Helpers';
 import fhirpath from 'fhirpath';
 
 interface Props {
@@ -45,7 +45,7 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
         const measureResource =
           measureFile.content === null
             ? null
-            : findValueSetName(measureFile.content, fhirpath.evaluate(valueSetObj, 'valueSet')[0]);
+            : findMeasureInBundle(measureFile.content, fhirpath.evaluate(valueSetObj, 'valueSet')[0]);
 
         return (
           <Accordion key={guidanceResponseId}>

--- a/src/components/Results/DetectedIssueResources.tsx
+++ b/src/components/Results/DetectedIssueResources.tsx
@@ -5,7 +5,7 @@ import { R4 } from '@ahryman40k/ts-fhir-types';
 import { Enums } from 'fqm-execution';
 import { measureFileState } from '../../state';
 import { useRecoilValue } from 'recoil';
-import { findMeasureInBundle } from '../Helpers';
+import { findValueSetInBundle } from '../Helpers';
 import fhirpath from 'fhirpath';
 
 interface Props {
@@ -42,10 +42,10 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
         const link = 'http://hl7.org/fhir/';
         const valueSetObj = codeFilters.find((cf: any) => cf.valueSet);
         const codeFilterArray = codeFilters.filter((cf: any) => !cf.valueSet);
-        const measureResource =
+        const valueSetResource =
           measureFile.content === null
             ? null
-            : findMeasureInBundle(measureFile.content, fhirpath.evaluate(valueSetObj, 'valueSet')[0]);
+            : findValueSetInBundle(measureFile.content, fhirpath.evaluate(valueSetObj, 'valueSet')[0]);
 
         return (
           <Accordion key={guidanceResponseId}>
@@ -74,7 +74,7 @@ const DetectedIssueResources: React.FC<Props> = ({ detectedIssue }) => {
                     <h5>{fhirpath.evaluate(valueSetObj, 'path')}:</h5>
                   </Grid>
                   <Grid item xs>
-                    {fhirpath.evaluate(measureResource, 'resource.name')}:
+                    {valueSetResource?.name}:
                     <Typography style={{ overflowWrap: 'break-word' }}>
                       <Link href={fhirpath.evaluate(valueSetObj, 'valueSet')}>
                         {fhirpath.evaluate(valueSetObj, 'valueSet')}


### PR DESCRIPTION
**Summary**
The name of the value set now appears next to the value set URL in each guidance response.

**New Behavior**
See above.

**Code Changes**
Changes were made to BundleHelpers.ts (formally PatientHelper.ts but I changed it to better reflect the two functions it contains) and DetectedIssueResources.tsx. BundleHelpers.ts now has a function called findMeasureInBundle which finds the measure in the measure bundle whose URL matches the input URL. This function is called in DetectedIssueResources.tsx so the valueSet name can be grabbed from that measure and rendered in the accordion.
